### PR TITLE
Dwedul/2 fix weird paths

### DIFF
--- a/json_info.sh
+++ b/json_info.sh
@@ -180,7 +180,7 @@ EOF
     # In order to handle paths that have spaces or other weird stuff, I'm putting them all in a string first instead of an array.
     # Later each line will be read out and put back into an array.
     paths_str=''
-    jq_filter='path(..)|reduce .[] as $item (""; if ($item|type) == "number" or ($item|@json|test("\\\\")) then . + "[" + ($item|@json) + "]" else . + "." + $item  end ) | if . == "" then "." elif .[0:1] != "." then "." + . else . end'
+    jq_filter='path(..)|reduce .[] as $item (""; if ($item|type) == "number" or ($item|@json|test("^\"[a-zA-Z_][a-zA-Z0-9_]*\"$")|not) then . + "[" + ($item|@json) + "]" else . + "." + $item  end ) | if . == "" then "." elif .[0:1] != "." then "." + . else . end'
     if [[ "${#paths_in[@]}" -eq '0' ]]; then
         # If no paths were provided, either just use '.' or get them all.
         if [[ -z "$recurse" ]]; then

--- a/json_info.sh
+++ b/json_info.sh
@@ -34,7 +34,7 @@ Usage: json_info [-p <path>] [-r] [-d] [--show-path|--hide-path|--just-paths] [-
     -r is an optional flag indicating that the paths provided are starting points,
         and that all paths beyond that point should also be used.
         Supplying this once will apply it to all provided paths.
-        Supplying this more than once has no affect.
+        Supplying this more than once has no extra affect.
         If no paths are provided, all paths in the json are used.
 
     -d is an optional flag indicating that for objects and arrays, the pretty json should be in the output.

--- a/tests/weird-paths.json
+++ b/tests/weird-paths.json
@@ -18,5 +18,6 @@
   "another_thing": "underscore in the middle",
   "a \"double quoted\" string": "a string with double quote characters",
   "a 'single quoted' string": "a string with single quote characters",
+  "85": "only a number",
   "normal": "just a normal thing"
 }

--- a/tests/weird-paths.json
+++ b/tests/weird-paths.json
@@ -1,0 +1,22 @@
+{
+  "mainthing": {
+    "/foo/{foo}/bar/{bar}": {
+      "barkey1": "barvalue1",
+      "barkey2": "barvalue2"
+    },
+    "/foo/{foo}/baz/{baz}": {
+      "bazkey1": "bazvalue1",
+      "bazkey2": "bazvalue2"
+    }
+  },
+  "1otherthing": "starts with number",
+  "five4three": "number in the middle",
+  " lots of space ": "starts with and has spaces",
+  "a space": "has a single space in the middle",
+  "_": "Just an underscore",
+  "_thingThree": "starts with underscore",
+  "another_thing": "underscore in the middle",
+  "a \"double quoted\" string": "a string with double quote characters",
+  "a 'single quoted' string": "a string with single quote characters",
+  "normal": "just a normal thing"
+}


### PR DESCRIPTION
Fixes `json_info` path generation to account for more than just escaped characters in the object field names.

Now, if the field name does not conform to `^[a-zA-Z_][a-zA-Z0-9_]*$` then it will be written as `["<name>"]` in the path, otherwise, the shorthand `.<name>` will be used.

Tested this using a new test file with problematic field names.
Both `json_info` and `json_explorer` were tested. The `json_info` function now outputs paths better. And the `json_explorer` function is now able to properly populate the fzf preview window for previously problematic paths.

Closes: #2 

