### PR TITLE
Performance improvements for json_info.sh

### DIFF
--- a/json_info.sh
+++ b/json_info.sh
@@ -201,7 +201,7 @@ EOF
         done
     fi
 
-    check_str_len='false'
+    check_str_len=''
     # A max width of 0 is treated as deactivating the max-width behavior.
     if [[ -z "$max_string" ]]; then
         # If no max string width was given, look for a FZF_PREVIEW_COLUMNS value.
@@ -215,7 +215,7 @@ EOF
                 # If the window is skinnier than the minimum truncation width, skip truncation.
                 max_string=0
             elif [[ -n "$show_path" ]]; then
-                check_str_len='true'
+                check_str_len='yes'
             fi
         else
             max_string=0
@@ -223,7 +223,7 @@ EOF
     fi
 
     jq_args=( --arg recurse "$recurse" --arg show_path "$show_path" --arg show_data "$show_data" --arg path_delim "$path_delim" )
-    jq_args+=( --argjson check_str_len "$check_str_len" --argjson max_string "$max_string" --argjson min_trunc "$min_trunc" )
+    jq_args+=( --arg check_str_len "$check_str_len" --argjson max_string "$max_string" --argjson min_trunc "$min_trunc" )
     if [[ -n "$input_file" ]]; then
         jq_args+=( --slurpfile data "$input_file" )
     elif [[ -n "$input" ]]; then


### PR DESCRIPTION
Major overhaul of json_info.sh.

closes: #8 

Simplify the overall process significantly:
1.  No more `while read` loop.
2. Now `jq` is called once to check the provided json, once again for each `-p` or `--path` option, plus one more time. Previously, `jq` was called once to check the json, once again per provided `-p` or `--path`, then again for each final path, then possibly again for `-d`.

The only functional difference between the old version and new version is that previously, the `-d` flag was ignored if `--just-paths` was provided and now it is usable.

### Timings

File used for testing:
```sh
> wc big_huge.json
       1       1 22318533 big_huge.json
```

Before:
```sh
> time { json_info --just-paths -r -f big_huge.json; }
```
```
real    36m7.578s
user    35m50.687s
sys 0m8.512s
```

After:
```sh
> time { json_info --just-paths -r -f big_huge.json; }
```
```
real    0m31.569s
user    0m24.490s
sys 0m0.804s
```

For comparison with json_search:
```sh
> time { json_search -q '.' -f big_huge.json; }
```
```
real    0m22.782s
user    0m20.286s
sys 0m0.587s
```