### PR TITLE
Fix the json_explorer preview window in fzf.

### DIFF
--- a/json_explorer.sh
+++ b/json_explorer.sh
@@ -15,7 +15,11 @@
 
 json_explorer () {
     local do_not_run
-    for req_cmd in 'jq' 'fzf' 'json_info'; do
+    if [[ -z "$JSON_INFO_CMD" ]]; then
+        printf 'unable to locate json_info script.\n' >&2
+        return 1
+    fi
+    for req_cmd in 'jq' 'fzf' 'json_info' "$JSON_INFO_CMD"; do
         if ! command -v "$req_cmd" > /dev/null 2>&1; then
             do_not_run='yes'
             printf 'Missing required command: %s\n' "$req_cmd" >&2
@@ -64,7 +68,7 @@ EOF
     fi
 
     # Prompt for paths to be selected
-    selections="$( json_info --just-paths -r -f "$filename" | fzf --multi --preview="printf '%s\n' {} && json_info -p {} -f '$filename' -d" --preview-window=':40%:wrap' --tac --cycle )"
+    selections="$( json_info --just-paths -r -f "$filename" | fzf --multi --preview="printf '%s\n' {} && '$JSON_INFO_CMD' -p {} -f '$filename' -d" --preview-window=':40%:wrap' --tac --cycle )"
     result='[]'
     while IFS= read -r jpath; do
         if [[ -n "$jpath" ]]; then

--- a/json_info.sh
+++ b/json_info.sh
@@ -296,12 +296,10 @@ if [[ "$sourced" != 'YES' ]]; then
     exit $?
 fi
 unset sourced
-cannot_export_f="$( export -f json_info )"
-if [[ -n "$cannot_export_f" ]]; then
-    export json_info="$( sed 's/^json_info ()/()/' <<< "$cannot_export_f" )"
-else
-    export -f json_info
-fi
-unset cannot_export
+# The json_info command is used in the preview window of fzf for the json_explorer.
+# But fzf can't find local environment functions, and exporting isn't always an option.
+# In order to get around that, in here, we'll just set a JSON_INFO_CMD env var that points to this file.
+# Then, over there, we can just use that instead of trying to call the json_info as a function.
+export JSON_INFO_CMD="$( readlink -f "${BASH_SOURCE:-$0}" )"
 
 return 0


### PR DESCRIPTION
closes: #19 

The `json_info.sh` file now exports `JSON_INFO_CMD` with the path to where that file is. This is done instead of trying to export the `json_info` function.

Then, in `json_explorer`, instead of calling `json_info` in the preview, call `$JSON_INFO_CMD`.